### PR TITLE
Use Monolog in a more standard way

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "version": "0.1.0",
     "require": {
         "php": "^7.1",
-        "monolog/monolog": "1.25.*"
+        "monolog/monolog": "1.25.*",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "datadog/dd-trace": "0.34.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a6e96837ffdc1dd6a5b19cca68f79c5",
+    "content-hash": "c1982f94e49d18a405962027d8824b4b",
     "packages": [
         {
             "name": "monolog/monolog",

--- a/example.php
+++ b/example.php
@@ -16,7 +16,7 @@ Bufflog::warning("I am a warning", ["duration" => "40ms"]);
 Bufflog::error("I am an error");
 Bufflog::error("I am an error", ["mean" => "70"]);
 
-Bufflog::critical("I am critical information!");
+Bufflog::criticals("I am criticals information with a typo and you shouldn't see me!");
 Bufflog::critical("I am critical information!", ["user" => "betrand"]);
 
 Bufflog::critical("I'm critical log, here some extra fancy informations", 

--- a/example.php
+++ b/example.php
@@ -29,3 +29,5 @@ Bufflog::critical("I'm critical log, here some extra fancy informations",
                         ]
                     ]
                 );
+
+echo(BuffLog::getName());

--- a/example.php
+++ b/example.php
@@ -27,7 +27,4 @@ Bufflog::critical("I'm critical log, here some extra fancy informations",
                             "Facebook",
                             "Instagram"
                         ]
-                    ]
-                );
-
-echo(BuffLog::getName());
+                    ]);

--- a/src/php-bufflog/BuffLog.php
+++ b/src/php-bufflog/BuffLog.php
@@ -135,15 +135,6 @@ class BuffLog {
         });
     }
 
-    private static function formatLog()
-    {
-        try {
-            $output = json_encode($output, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        } catch (Exception $e) {
-            error_log("can't json_encode your message");
-        }
-    }
-
     private static function setVerbosity()
     {
         $envVerbosity = getenv("LOG_VERBOSITY");

--- a/src/php-bufflog/BuffLog.php
+++ b/src/php-bufflog/BuffLog.php
@@ -113,7 +113,7 @@ class BuffLog {
     {
         // This should probably implemented as a Monolog Processor
         // https://github.com/Seldaek/monolog/tree/master/src/Monolog/Processor
-        $self::getLogger()->pushProcessor(function ($record) {
+        self::getLogger()->pushProcessor(function ($record) {
 
             // We should grab any Buffer information useful when available
             // Need to check with the Core team: accountID / userID / profileID

--- a/src/php-bufflog/BuffLog.php
+++ b/src/php-bufflog/BuffLog.php
@@ -19,7 +19,7 @@ class BuffLog {
     ];
 
     private static $logOutputMethods = ['debug', 'info', 'notice', 'warning', 'error', 'critical'];
-    private static $extraAllowedMethods = ['getName'];
+    private static $extraAllowedMethods = ['getName', 'pushHandler', 'setHandlers', 'getHandlers', 'pushProcessor', 'getProcessors'];
 
 	/**
 	 * Method to return the Monolog instance


### PR DESCRIPTION
This PR : 
- Expose some Monolog methods to developers
- Use a more standard way to use Monolog for formatting and enrich logs

## Use Monolog Processor to "enrich" information
[Instead of defining ourself the format](https://github.com/bufferapp/php-bufflog/pull/7/files#diff-863c0e56954fd2b45927142787734103L87-L101), we use Processors (as recommended by [Datadog](https://docs.datadoghq.com/logs/log_collection/php/?tab=phpmonolog#adding-more-context))

Talked with @esclapes and standard fields in pinojs might differ from Monolog ones. for example Monolog use `message` and Pino `msg`. We will need to agree into one or the other. Also Monolog will always send the `extra` fields (if we will use any of the [processor](https://github.com/Seldaek/monolog/tree/master/src/Monolog/Processor). Discussion still going on with #2  

## Use Formatter for JSON format
Instead of converting manually, we simply said to Monolog we want the format to be JSON via [the JSONFormatter](https://github.com/bufferapp/php-bufflog/pull/7/files#diff-863c0e56954fd2b45927142787734103R45)

## "Proxy" methods to monolog
- Use the `call_user_func_array` function to proxy to the Monolog instance
- We also let developer to use a "whitelisted" list of Monolog functions in case they want to use and other

## The output now will look like that:
```json
{"message":"I am a warning","context":{"dd":{"trace_id":"","span_id":""}},"level":300,"level_name":"WARNING","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.465403","timezone_type":3,"timezone":"UTC"},"extra":[]}
{"message":"I am a warning","context":{"duration":"40ms","dd":{"trace_id":"","span_id":""}},"level":300,"level_name":"WARNING","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.466147","timezone_type":3,"timezone":"UTC"},"extra":[]}
{"message":"I am an error","context":{"dd":{"trace_id":"","span_id":""}},"level":400,"level_name":"ERROR","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.466177","timezone_type":3,"timezone":"UTC"},"extra":[]}
{"message":"I am an error","context":{"mean":"70","dd":{"trace_id":"","span_id":""}},"level":400,"level_name":"ERROR","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.466196","timezone_type":3,"timezone":"UTC"},"extra":[]}
{"message":"I am critical information!","context":{"dd":{"trace_id":"","span_id":""}},"level":500,"level_name":"CRITICAL","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.466221","timezone_type":3,"timezone":"UTC"},"extra":[]}
{"message":"I am critical information!","context":{"user":"betrand","dd":{"trace_id":"","span_id":""}},"level":500,"level_name":"CRITICAL","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.466238","timezone_type":3,"timezone":"UTC"},"extra":[]}
{"message":"I'm critical log, here some extra fancy informations","context":{"duration":"40ms","services_related":["Twitter","Facebook","Instagram"],"dd":{"trace_id":"","span_id":""}},"level":500,"level_name":"CRITICAL","channel":"php-bufflog","datetime":{"date":"2019-11-28 06:09:58.466255","timezone_type":3,"timezone":"UTC"},"extra":[]}
```

## Review
@esclapes @colinscape  good to have your eyes on this?

The `extra` fields (that was confusing with the #2) will also be present.  I'm wondering if [pinoJS](https://github.com/pinojs/pino) also  add this `extra` and `context` fields?
Anyway we can still iterate on this until we find a good solution for us. We don't have to strictly follow Monolog or Pino conventions. Just having both PHP and JS Bufflog libraries that follow the same (Buffer) standard that make sense for our developers :) 

I'm still wondering  if of a whitelisting only some methods is okay? I think it's okay because we intend the developer to use our Lib in a specific way without giving letting them do too many crazy things.