### PR TITLE
Check datadog if class exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bufferapp/php-bufflog",
     "description": "PHP log libraries for Buffer services",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "require": {
         "php": "^7.1",
         "monolog/monolog": "^1.20",

--- a/src/BuffLog/BuffLog.php
+++ b/src/BuffLog/BuffLog.php
@@ -36,6 +36,12 @@ class BuffLog {
 
 	protected static function configureInstance()
 	{
+
+        if (!class_exists("\DDTrace\GlobalTracer")) {
+            error_log("Tip #1: Can't find \DDTrace\GlobalTracer class. Did you install the Datadog APM tracer extension? It will allow you to have logs enriched with traces making troubleshooting easier! :)");
+            error_log("Tip #2: If you run a cli mode service (such as a worker), did you set the DD_TRACE_CLI_ENABLED env variable?");
+        }
+
         // @TODO: We could potentially use the Kubernetes downward API to
         // define the logger name. This will make it easier for developers
         // to read and friendlier to identify where come the logs at a glance
@@ -105,7 +111,7 @@ class BuffLog {
                 ];
 
             } catch (Exception $e) {
-                error_log($e->getMessage() . " If you run a cli mode service (such as a worker), did you set the DD_TRACE_CLI_ENABLED env variable?");
+                error_log($e->getMessage() . " Can't add trace to logs. Have you setup the Datadog Tracer extension? If you run a worker have your added the DD_TRACE_CLI_ENABLED env variable?");
             }
 
             return $record;

--- a/src/BuffLog/BuffLog.php
+++ b/src/BuffLog/BuffLog.php
@@ -84,12 +84,18 @@ class BuffLog {
             //     'profileID' => $user->getProfileID()
             // );
 
-            // Add traces information to logs to be able correlate with APM
-            $ddTraceSpan = \DDTrace\GlobalTracer::get()->getActiveSpan();
-            $record['context']['dd'] = [
-                "trace_id" => $ddTraceSpan->getTraceId(),
-                "span_id"  => $ddTraceSpan->getSpanId()
-            ];
+            try {
+                // Add traces information to logs to be able correlate with APM
+                $ddTraceSpan = \DDTrace\GlobalTracer::get()->getActiveSpan();
+                $record['context']['dd'] = [
+                    "trace_id" => $ddTraceSpan->getTraceId(),
+                    "span_id"  => $ddTraceSpan->getSpanId()
+                ];
+
+            } catch (Exception $e) {
+                error_log($e->getMessage() . " If you run a cli mode service (such as a worker), did you set the DD_TRACE_CLI_ENABLED env variable?");
+            }
+
             return $record;
         });
     }


### PR DESCRIPTION
This PR:
- check if `\DDTrace\GlobalTracer` (is installed by  datadog apm extension), exists
- We also catch the exception if `\DDTrace\GlobalTracer::get()->getActiveSpan()` throw an error
 - should solve #3 #4 #10 

@colinscape up for a review? :) 