### PR TITLE
Handle DDTrace\GlobalTracer class missing exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bufferapp/php-bufflog",
     "description": "PHP log libraries for Buffer services",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "require": {
         "php": "^7.1",
         "monolog/monolog": "^1.20",

--- a/src/BuffLog/BuffLog.php
+++ b/src/BuffLog/BuffLog.php
@@ -103,6 +103,11 @@ class BuffLog {
             // );
 
             try {
+
+                if (class_exists("\DDTrace\GlobalTracer", false) === false) {
+                    throw new \Exception('DDTrace\GlobalTracer can\'t be found. Have you setup the Datadog Tracer extension? If you run cli worker, have you added the DD_TRACE_CLI_ENABLED env variable?');
+                }
+
                 // Add traces information to be able to correlate logs with APM
                 $ddTraceSpan = \DDTrace\GlobalTracer::get()->getActiveSpan();
                 $record['context']['dd'] = [
@@ -110,8 +115,9 @@ class BuffLog {
                     "span_id"  => $ddTraceSpan->getSpanId()
                 ];
 
-            } catch (Exception $e) {
-                error_log($e->getMessage() . " Can't add trace to logs. Have you setup the Datadog Tracer extension? If you run a worker have your added the DD_TRACE_CLI_ENABLED env variable?");
+            } catch (\Exception $e) {
+                // we probably will want to make an no-op or it will be too verbose
+                error_log($e->getMessage() . " Traces will not be added in the logs");
             }
 
             return $record;


### PR DESCRIPTION
Output an error log when we can't load the `DDTrace\GlobalTracer` present in the [DD APM Tracing extension](https://docs.datadoghq.com/tracing/setup/php/) . 

Using that library would throw a FATAL exception if the DD APM tracing extension is not installed what isn't great.  This is important because some services would set it only  for logging (and not tracing). 

Also related to #3 