### PR TITLE
"Type safety"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bufferapp/php-bufflog",
     "description": "PHP log libraries for Buffer services",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "require": {
         "php": "^7.1",
         "monolog/monolog": "^1.20",

--- a/example.php
+++ b/example.php
@@ -5,7 +5,10 @@ require_once('./src/BuffLog/BuffLog.php');
 use Buffer\BuffLog\Bufflog;
 
 // putenv("LOG_VERBOSITY=WARNING");
-BuffLog::debug("I am a debug string");
+BuffLog::debug("I am a debug string", 2, 2);
+BuffLog::debug(["I am a"]);
+BuffLog::debug("I am a", "test");
+BuffLog::debug("I am a debug string", 2, 2);
 BuffLog::debug("I am a debug with context", ["my key" => " my value"]);
 
 BuffLog::info("I am an info");
@@ -14,7 +17,7 @@ BuffLog::info("I am a info with context", ["my key" => " my value"]);
 BuffLog::warning("I am a warning");
 BuffLog::warning("I am a warning", ["duration" => "40ms"]);
 
-BuffLog::error("I am an error");
+BuffLog::error(2);
 BuffLog::error("I am an error", ["mean" => "70"]);
 
 BuffLog::critical("I am criticals information with a typo and you shouldn't see me!");

--- a/example.php
+++ b/example.php
@@ -5,7 +5,7 @@ require_once('./src/BuffLog/BuffLog.php');
 use Buffer\BuffLog\Bufflog;
 
 // putenv("LOG_VERBOSITY=WARNING");
-BuffLog::debug("I am a debug");
+BuffLog::debug("I am a debug string");
 BuffLog::debug("I am a debug with context", ["my key" => " my value"]);
 
 BuffLog::info("I am an info");

--- a/src/BuffLog/BuffLog.php
+++ b/src/BuffLog/BuffLog.php
@@ -45,8 +45,12 @@ class BuffLog {
         } else {
             // local envs don't need tracing
             if (getenv("ENVIRONMENT") !== "local") {
-                error_log("Tip #1: Can't find \DDTrace\GlobalTracer class. Did you install the Datadog APM tracer extension? It will allow you to have logs enriched with traces making troubleshooting easier.");
-                error_log("Tip #2: If you run a cli mode service (such as a worker), did you set the DD_TRACE_CLI_ENABLED env variable?");
+                echo json_encode([
+                        "message" => "Can't find \DDTrace\GlobalTracer class. Did you install the Datadog APM tracer extension? It will allow you to have logs enriched with traces making troubleshooting easier. If you run a cli mode service (such as a worker), did you set the DD_TRACE_CLI_ENABLED env variable?",
+                        "level" => 300,
+                        "level_name" => "WARNING",
+                        "context" => ["bufflog_error" => "no_tracer"]
+                ]);
             }
         }
 
@@ -117,10 +121,10 @@ class BuffLog {
                     }
                 }
             } else {
-                error_log("BuffLog::$methodName() is not supported yet. Add it to the BuffLog whitelist to allow it");
+                self::getLogger()->warning("BuffLog::$methodName() is not supported yet. Add it to the BuffLog whitelist to allow it", ["bufflog_error" => "method_not_supported"]);
             }
         } else {
-            error_log("BuffLog::$methodName() method does not exist");
+            self::getLogger()->warning("BuffLog::$methodName() method does not exist", ["bufflog_error" => "method_not_exist"]);
         }
 
         return false;
@@ -129,17 +133,17 @@ class BuffLog {
     private static function checkLogParametersType($args)
     {
         if (count($args) > 2) {
-            error_log("BuffLog: Too many parameters");
+            self::getLogger()->warning("BuffLog: Malformed logs: Too many parameters", ["bufflog_error" => "incorrect_parameters", "args" => $args]);
             return false;
         }
 
         if (isset($args[0]) && !is_string($args[0])) {
-            error_log("BuffLog: First parameter must be a string");
+            self::getLogger()->warning("BuffLog: Malformed logs: First parameter must be a string", ["args" => $args, "bufflog_error" => "incorrect_parameters"]);
             return false;
         }
 
         if (isset($args[1]) && !is_array($args[1])) {
-            error_log("BuffLog: Second parameter must be an array");
+            self::getLogger()->warning("BuffLog: Malformed logs: Second parameter must be an array", ["args" => $args, "bufflog_error" => "incorrect_parameters"]);
             return false;
         }
 

--- a/src/BuffLog/BuffLog.php
+++ b/src/BuffLog/BuffLog.php
@@ -110,8 +110,11 @@ class BuffLog {
             if (in_array($methodName, array_merge(self::$logOutputMethods, self::$extraAllowedMethods))) {
 
                 if (in_array($methodName, self::$logOutputMethods)) {
-                    // Where the magic happen. We "proxy" functions name with arguments to the Monolog instance
-                    return call_user_func_array(array(self::getLogger(), $methodName), $args);
+
+                    if (self::checkLogParametersType($args)) {
+                        // Where the magic happen. We "proxy" functions name with arguments to the Monolog instance
+                        return call_user_func_array(array(self::getLogger(), $methodName), $args);
+                    }
                 }
             } else {
                 error_log("BuffLog::$methodName() is not supported yet. Add it to the BuffLog whitelist to allow it");
@@ -119,6 +122,28 @@ class BuffLog {
         } else {
             error_log("BuffLog::$methodName() method does not exist");
         }
+
+        return false;
+    }
+
+    private static function checkLogParametersType($args)
+    {
+        if (count($args) > 2) {
+            error_log("BuffLog: Too many parameters");
+            return false;
+        }
+
+        if (isset($args[0]) && !is_string($args[0])) {
+            error_log("BuffLog: First parameter must be a string");
+            return false;
+        }
+
+        if (isset($args[1]) && !is_array($args[1])) {
+            error_log("BuffLog: Second parameter must be an array");
+            return false;
+        }
+
+        return true;
     }
 
 }


### PR DESCRIPTION
We got [few incidents](https://buffer.slack.com/archives/C0KS2S8D7/p1582934559012400) when passing the wrong type of parameters.  Since it makes the PHP erroring out and make a full service stop,  I simply output an error message instead of stopping the script execution. 

I was thinking to use the [type-hint](https://wiki.php.net/rfc/object-typehint) but since we use the magic function `call_user_func_array` i'm not too sure how to do it altogether. 

@colinscape up for a review? 
