### PR TITLE
Fix uppercase `L` in BuffLog namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "bufferapp/php-bufflog",
     "description": "PHP log libraries for Buffer services",
-    "version": "0.1.6",
+    "version": "0.2.0",
     "require": {
         "php": "^7.1",
         "monolog/monolog": "^1.20",

--- a/src/BuffLog/BuffLog.php
+++ b/src/BuffLog/BuffLog.php
@@ -1,5 +1,5 @@
 <?php
-namespace Buffer\Bufflog;
+namespace Buffer\BuffLog;
 
 use Monolog\Logger as Logger;
 use Monolog\Handler\StreamHandler;


### PR DESCRIPTION
Fix a subtle, but improper letter case.

This might be why [we can't use --classmap-authoritative when dumping the autolaod](https://github.com/bufferapp/buffer-web/pull/16729#issuecomment-590816948), as it would conflict with the declared namespace.