### PR TITLE
Update PHP, monolog and datadog versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PHP logger for all Buffer services
 
 ## Requirements
 
-PHP 7.1 and later.
+PHP 8.1 and later.
 
 ## Setup BuffLog in your PHP project via Composer
 

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
     "name": "bufferapp/php-bufflog",
     "description": "PHP log libraries for Buffer services",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "require": {
-        "php": "^7.1",
-        "monolog/monolog": "^1.20",
-        "psr/log": "^1.1"
+        "php": ">=8.1",
+        "monolog/monolog": "^3.2",
+        "psr/log": "^3.0"
     },
     "require-dev": {
-        "datadog/dd-trace": "0.34.*"
+        "datadog/dd-trace": "0.82.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,59 +4,68 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fd988db8b88b017b429444cd494da3b",
+    "content-hash": "64f5da0e999e9ad6bc4f5c4184e7a7ce",
     "packages": [
         {
             "name": "monolog/monolog",
-            "version": "1.25.2",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "d5e2fb341cb44f7e2ab639d12a1e5901091ec287"
+                "reference": "305444bc6fb6c89e490f4b34fa6e979584d7fa81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/d5e2fb341cb44f7e2ab639d12a1e5901091ec287",
-                "reference": "d5e2fb341cb44f7e2ab639d12a1e5901091ec287",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/305444bc6fb6c89e490f4b34fa6e979584d7fa81",
+                "reference": "305444bc6fb6c89e490f4b34fa6e979584d7fa81",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0",
-                "psr/log": "~1.0"
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0"
+                "psr/log-implementation": "3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "aws/aws-sdk-php": "^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "graylog2/gelf-php": "~1.0",
-                "jakub-onderka/php-parallel-lint": "0.9",
-                "php-amqplib/php-amqplib": "~2.4",
-                "php-console/php-console": "^3.1.3",
-                "phpunit/phpunit": "~4.5",
-                "phpunit/phpunit-mock-objects": "2.3.0",
-                "ruflin/elastica": ">=0.90 <3.0",
-                "sentry/sentry": "^0.13",
-                "swiftmailer/swiftmailer": "^5.3|^6.0"
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2",
+                "guzzlehttp/guzzle": "^7.4",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^9.5.16",
+                "predis/predis": "^1.1",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
                 "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
                 "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
-                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
                 "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
-                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
                 "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
-                "php-console/php-console": "Allow sending log messages to Google Chrome",
                 "rollbar/rollbar": "Allow sending log messages to Rollbar",
-                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
-                "sentry/sentry": "Allow sending log messages to a Sentry server"
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -72,44 +81,58 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
+            "homepage": "https://github.com/Seldaek/monolog",
             "keywords": [
                 "log",
                 "logging",
                 "psr-3"
             ],
-            "time": "2019-11-13T10:00:05+00:00"
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-24T12:00:55+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.1.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
+                    "Psr\\Log\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -119,7 +142,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -129,66 +152,62 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01T11:05:21+00:00"
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "datadog/dd-trace",
-            "version": "0.34.0",
+            "version": "0.82.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DataDog/dd-trace-php.git",
-                "reference": "14d24b6c329a9e17facd37ee9465afc443f865da"
+                "reference": "002e752d837313624fe32f448d83a67f2451b1d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DataDog/dd-trace-php/zipball/14d24b6c329a9e17facd37ee9465afc443f865da",
-                "reference": "14d24b6c329a9e17facd37ee9465afc443f865da",
+                "url": "https://api.github.com/repos/DataDog/dd-trace-php/zipball/002e752d837313624fe32f448d83a67f2451b1d3",
+                "reference": "002e752d837313624fe32f448d83a67f2451b1d3",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
-                "php": "~5.4.0 || ~5.6.0 || ^7.0"
+                "php": "^5.4 || ^7.0 || ^8.0.0"
             },
             "require-dev": {
+                "ext-posix": "*",
                 "g1a/composer-test-scenarios": "~3.0",
                 "mockery/mockery": "*",
-                "phpunit/phpunit": "^4",
+                "phpunit/phpunit": "*",
                 "squizlabs/php_codesniffer": "^3.3.0",
-                "symfony/process": "*"
+                "symfony/process": "<5"
             },
             "type": "library",
             "extra": {
                 "scenarios": {
-                    "elasticsearch1": {
+                    "opentracing_beta5": {
                         "require": {
-                            "elasticsearch/elasticsearch": "1.2.*"
+                            "opentracing/opentracing": "1.0.0-beta5"
                         },
                         "scenario-options": {
                             "create-lockfile": false
                         }
                     },
-                    "guzzle5": {
+                    "opentracing_beta6": {
                         "require": {
-                            "guzzlehttp/guzzle": "~5.0"
+                            "opentracing/opentracing": "1.0.0-beta6"
                         },
                         "scenario-options": {
                             "create-lockfile": false
                         }
                     },
-                    "guzzle6": {
+                    "opentracing10": {
                         "require": {
-                            "guzzlehttp/guzzle": "~6.0"
-                        },
-                        "scenario-options": {
-                            "create-lockfile": false
-                        }
-                    },
-                    "predis1": {
-                        "require": {
-                            "predis/predis": "^1.1"
+                            "opentracing/opentracing": "^1.0"
                         },
                         "scenario-options": {
                             "create-lockfile": false
@@ -200,8 +219,11 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "./src/api/ComposerBootstrap.php"
+                ],
                 "psr-4": {
-                    "DDTrace\\": "./src/DDTrace/"
+                    "DDTrace\\": "./src/api/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -225,7 +247,11 @@
                 "php",
                 "tracing"
             ],
-            "time": "2019-10-29T17:16:09+00:00"
+            "support": {
+                "issues": "https://github.com/DataDog/dd-trace-php/issues",
+                "source": "https://github.com/DataDog/dd-trace-php/tree/0.82.0"
+            },
+            "time": "2022-12-06T09:23:16+00:00"
         }
     ],
     "aliases": [],
@@ -234,7 +260,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": ">=8.1"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
### What the PR Does
This updates the PHP, monolog and datadog versions to be compatible with PHP 8.1 and above

### Why?
The PHP projects to be updates to >= 8.1 rely on this logging library, so this library needs to be updated first for compatibility.

[Monolog package](https://packagist.org/packages/monolog/monolog)

[dd-trace package](https://packagist.org/packages/datadog/dd-trace)
